### PR TITLE
Build merged Microsoft.Cci.dll against .NETStandard 1.3

### DIFF
--- a/CoreObjectModel/MetadataHelper/UnitHelper.cs
+++ b/CoreObjectModel/MetadataHelper/UnitHelper.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Cci {
       Contract.Requires(metadataHost != null);
       Contract.Ensures(Contract.Result<AssemblyIdentity>() != null);
 
-      string culture = assemblyName.CultureInfo == null || assemblyName.CultureInfo == System.Globalization.CultureInfo.InvariantCulture ? "neutral" : assemblyName.CultureInfo.ToString();
+      string culture = String.IsNullOrEmpty(assemblyName.CultureName) ? "neutral" : assemblyName.CultureName;
       string name = assemblyName.Name;
       if (name == null) name = string.Empty;
       Version version = assemblyName.Version;

--- a/Microsoft.Cci.csproj
+++ b/Microsoft.Cci.csproj
@@ -49,7 +49,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|amd64' ">
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETStandard' ">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Microsoft.Cci.csproj
+++ b/Microsoft.Cci.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-  <Import Project="..\dir.settings.targets"  Condition="Exists('..\dir.settings.targets')" />
+  <Import Project="..\dir.settings.targets" Condition="Exists('..\dir.settings.targets')" />
   <PropertyGroup>
     <!-- Make sure building in VS get chk by default -->
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -15,7 +15,11 @@
     <NoWarn>$(NoWarn);649</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug_GitHub|AnyCPU' ">
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.3</TargetFrameworkVersion>
+    <DefineConstants>$(DefineConstants);NO_STRING_CTOR_FROM_PTR_AND_ENCODING</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <NoWarn>$(NoWarn);618</NoWarn>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -25,7 +29,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release_GitHub|AnyCPU' ">
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkIdentifier>.NETStandard</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v1.3</TargetFrameworkVersion>
+    <DefineConstants>$(DefineConstants);NO_STRING_CTOR_FROM_PTR_AND_ENCODING</DefineConstants>
+    <NoWarn>$(NoWarn);618</NoWarn>
+    <NoStdLib>true</NoStdLib>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -41,7 +49,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|amd64' ">
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -49,8 +57,16 @@
   <Import Project=".\Microsoft.Cci.Sources.targets" />
   <Import Project="..\dir.targets" Condition="Exists('..\dir.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="!Exists('..\dir.targets')" />
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
+    <!-- Workaround to let us target .NETStandard on downlevel VS. Prevents errors about missing targeting pack. -->
+    <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)</_TargetFrameworkDirectories>
+    <_FullFrameworkReferenceAssemblyPaths>$(MSBuildThisFileDirectory)</_FullFrameworkReferenceAssemblyPaths>
+  </PropertyGroup>
   <ItemGroup>
     <!-- We want the sources to show up nicely in VS-->
     <VSSources Include="@(Compile)" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
   </ItemGroup>
 </Project>

--- a/PEReaderAndWriter/PEReader/UnmanagedReadWrite.cs
+++ b/PEReaderAndWriter/PEReader/UnmanagedReadWrite.cs
@@ -934,7 +934,7 @@ namespace Microsoft.Cci.UtilityDataStructures {
         {
             if (checked(this.CurrentPointer - this.Buffer + byteCount) > this.Length)
                 throw new ArgumentOutOfRangeException();
-#if HOST_CORERT
+#if HOST_CORERT || NO_STRING_CTOR_FROM_PTR_AND_ENCODING
           byte* pb = this.CurrentPointer;
           char[] buffer = new char[byteCount];
           int j = 0;

--- a/PEReaderAndWriter/PEWriter/MemoryStream.cs
+++ b/PEReaderAndWriter/PEWriter/MemoryStream.cs
@@ -39,11 +39,7 @@ namespace Microsoft.Cci.WriterUtilities {
       }
       set {
         byte[] myBuffer = this.Buffer;
-#if COMPACTFX // || COREFX_SUBSET
         uint n = (uint)myBuffer.Length;
-#else
-        uint n = (uint)myBuffer.LongLength;
-#endif
         if (value >= n) this.Grow(myBuffer, n, value);
         if (value > this.Length) this.Length = value;
         this.position = value;

--- a/PEReaderAndWriter/PEWriter/PeWriter.cs
+++ b/PEReaderAndWriter/PEWriter/PeWriter.cs
@@ -5066,8 +5066,8 @@ namespace Microsoft.Cci.PeWriterInternal {
     }
 #else
     public bool Equals(byte[] x, byte[] y) {
-      long n = x.LongLength;
-      if (n != y.LongLength) return false;
+      long n = x.Length;
+      if (n != y.Length) return false;
       for (long i = 0; i < n; i++) {
         if (x[i] != y[i]) return false;
       }
@@ -5076,7 +5076,7 @@ namespace Microsoft.Cci.PeWriterInternal {
 
     public int GetHashCode(byte[] x) {
       int hcode = 1;
-      for (long i = 0, n = x.LongLength; i < n; i++)
+      for (long i = 0, n = x.Length; i < n; i++)
         hcode = hcode * 17 + x[i];
       return hcode;
     }

--- a/project.json
+++ b/project.json
@@ -1,0 +1,10 @@
+﻿{
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "System.Collections.NonGeneric": "4.0.1",
+    "System.Diagnostics.Contracts": "4.0.1"
+  },
+  "frameworks": {
+    "netstandard1.3": {}
+  }
+}


### PR DESCRIPTION
@mike-barnett @terrajobst @tijoytom @weshaggard 

I couldn't go as low as 1.1 or 1.2 as #2 requests, but this should help getting a new .nupkg built from here.