### PR TITLE
Avoid an unnecessary pass in the copier, because Traverse *does* visi…

### DIFF
--- a/CoreObjectModel/MutableMetadataModel/Copier.cs
+++ b/CoreObjectModel/MutableMetadataModel/Copier.cs
@@ -3306,9 +3306,9 @@ namespace Microsoft.Cci.MutableCodeModel {
       Contract.Requires(!(assembly is Dummy));
       Contract.Ensures(Contract.Result<Assembly>() != null);
 
-      this.TraverseAndPopulateDefinitionCacheWithCopies.Traverse(assembly); //Does not traverse the types
-      foreach (var type in assembly.GetAllTypes())
-        this.TraverseAndPopulateDefinitionCacheWithCopies.Traverse(type);
+      this.TraverseAndPopulateDefinitionCacheWithCopies.Traverse(assembly); // Traverses the types, except for the <Module> type
+      var moduleType = new List<INamedTypeDefinition>(assembly.GetAllTypes())[0];
+      this.TraverseAndPopulateDefinitionCacheWithCopies.Traverse(moduleType);
       foreach (var module in assembly.MemberModules) {
         foreach (var mtype in module.GetAllTypes())
           this.TraverseAndPopulateDefinitionCacheWithCopies.Traverse(mtype);

--- a/CoreObjectModel/MutableMetadataModel/Copier.cs
+++ b/CoreObjectModel/MutableMetadataModel/Copier.cs
@@ -3306,9 +3306,12 @@ namespace Microsoft.Cci.MutableCodeModel {
       Contract.Requires(!(assembly is Dummy));
       Contract.Ensures(Contract.Result<Assembly>() != null);
 
-      this.TraverseAndPopulateDefinitionCacheWithCopies.Traverse(assembly); // Traverses the types, except for the <Module> type
-      var moduleType = new List<INamedTypeDefinition>(assembly.GetAllTypes())[0];
-      this.TraverseAndPopulateDefinitionCacheWithCopies.Traverse(moduleType);
+      this.TraverseAndPopulateDefinitionCacheWithCopies.Traverse(assembly); // Traverses root unit namespace and all of its members
+      foreach (var type in assembly.GetAllTypes())
+      {
+         this.TraverseAndPopulateDefinitionCacheWithCopies.Traverse(type);
+         break; // Above traversal goes through all of the types except for the first one, the special <Module> type
+      }
       foreach (var module in assembly.MemberModules) {
         foreach (var mtype in module.GetAllTypes())
           this.TraverseAndPopulateDefinitionCacheWithCopies.Traverse(mtype);


### PR DESCRIPTION
…t the root unit namespace and so traverses all of the members of that. It just doesn't traverse the <Module> type so that still needs to be done.