### PR TITLE
Cor flags bug

### DIFF
--- a/PEReaderAndWriter/PEReader/BinaryObjectModel.cs
+++ b/PEReaderAndWriter/PEReader/BinaryObjectModel.cs
@@ -492,7 +492,7 @@ namespace Microsoft.Cci.MetadataReader.ObjectModelImplementation {
     }
 
     bool IModule.Requires32bits {
-      get { return (this.Cor20Flags & (COR20Flags.Bit32Required|COR20Flags.Prefers32bits)) == COR20Flags.Bit32Required; }
+      get { return (this.Cor20Flags & COR20Flags.Bit32Required) == COR20Flags.Bit32Required; }
     }
 
     bool IModule.Requires64bits {

--- a/PEReaderAndWriter/PEReader/BinaryObjectModel.cs
+++ b/PEReaderAndWriter/PEReader/BinaryObjectModel.cs
@@ -492,7 +492,7 @@ namespace Microsoft.Cci.MetadataReader.ObjectModelImplementation {
     }
 
     bool IModule.Requires32bits {
-      get { return (this.Cor20Flags & COR20Flags.Bit32Required) == COR20Flags.Bit32Required; }
+      get { return (this.Cor20Flags & (COR20Flags.Bit32Required | COR20Flags.Prefers32bits)) == COR20Flags.Bit32Required; }
     }
 
     bool IModule.Requires64bits {

--- a/PEReaderAndWriter/PEReader/PEFileStructures.cs
+++ b/PEReaderAndWriter/PEReader/PEFileStructures.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Cci.MetadataReader.PEFileFlags {
     Bit32Required = 0x00000002,
     ILLibrary = 0x00000004,
     StrongNameSigned = 0x00000008,
+    NativeEntryPoint = 0x00000010,
     TrackDebugData = 0x00010000,
     Prefers32bits = 0x00020000,
   }

--- a/PEReaderAndWriter/PEReader/PEFileStructures.cs
+++ b/PEReaderAndWriter/PEReader/PEFileStructures.cs
@@ -152,8 +152,8 @@ namespace Microsoft.Cci.MetadataReader.PEFileFlags {
     Bit32Required = 0x00000002,
     ILLibrary = 0x00000004,
     StrongNameSigned = 0x00000008,
-    Prefers32bits = 0x00000010,
     TrackDebugData = 0x00010000,
+    Prefers32bits = 0x00020000,
   }
 
   internal enum MetadataStreamKind {

--- a/PEReaderAndWriter/PEReader/PEFileToObjectModel.cs
+++ b/PEReaderAndWriter/PEReader/PEFileToObjectModel.cs
@@ -914,8 +914,8 @@ namespace Microsoft.Cci.MetadataReader {
 
     internal IMethodReference GetEntryPointMethod() {
       //  TODO: Do we ever want to take care of Native methods?
-      //if ((this.PEFileReader.COR20Header.COR20Flags & COR20Flags.Prefers32bits) != 0)
-      //  return Dummy.MethodReference;
+      if ((this.PEFileReader.COR20Header.COR20Flags & COR20Flags.NativeEntryPoint) != 0)
+         return Dummy.MethodReference;
       uint tokenType = this.PEFileReader.COR20Header.EntryPointTokenOrRVA & TokenTypeIds.TokenTypeMask;
       if (tokenType == TokenTypeIds.File) {
         Assembly/*?*/ assem = this.Module as Assembly;

--- a/PEReaderAndWriter/PEReader/PEFileToObjectModel.cs
+++ b/PEReaderAndWriter/PEReader/PEFileToObjectModel.cs
@@ -914,8 +914,8 @@ namespace Microsoft.Cci.MetadataReader {
 
     internal IMethodReference GetEntryPointMethod() {
       //  TODO: Do we ever want to take care of Native methods?
-      if ((this.PEFileReader.COR20Header.COR20Flags & COR20Flags.Prefers32bits) != 0)
-        return Dummy.MethodReference;
+      //if ((this.PEFileReader.COR20Header.COR20Flags & COR20Flags.Prefers32bits) != 0)
+      //  return Dummy.MethodReference;
       uint tokenType = this.PEFileReader.COR20Header.EntryPointTokenOrRVA & TokenTypeIds.TokenTypeMask;
       if (tokenType == TokenTypeIds.File) {
         Assembly/*?*/ assem = this.Module as Assembly;

--- a/PEReaderAndWriter/PEWriter/PeWriter.cs
+++ b/PEReaderAndWriter/PEWriter/PeWriter.cs
@@ -1001,8 +1001,8 @@ namespace Microsoft.Cci {
       if (this.module.ILOnly) result |= 1;
       if (this.module.Requires32bits) result |= 2;
       if (this.module.StrongNameSigned) result |= 8;
-      if (this.module.Prefers32bits) result |= 0x12;
       if (this.module.TrackDebugData) result |= 0x10000;
+      if (this.module.Prefers32bits) result |= 0x20000;
       return result;
     }
 

--- a/PEReaderAndWriter/PEWriter/PeWriter.cs
+++ b/PEReaderAndWriter/PEWriter/PeWriter.cs
@@ -1002,7 +1002,7 @@ namespace Microsoft.Cci {
       if (this.module.Requires32bits) result |= 2;
       if (this.module.StrongNameSigned) result |= 8;
       if (this.module.TrackDebugData) result |= 0x10000;
-      if (this.module.Prefers32bits) result |= 0x20000;
+      if (this.module.Prefers32bits) result |= 0x20002;
       return result;
     }
 


### PR DESCRIPTION
This fixes some bugs that I came across while doing assembly rewriting. I'm not sure why the CorFlags issue hasn't been noticed before this. I would love for someone to look at the change to PEFileToObjectModel.cs:917--918. I'm not clear on why that code was there in the first place.